### PR TITLE
Adds in ability to not run doctrine commands

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@ symfony2_console_opts: ~
 
 symfony2_project_env: prod
 
+symfony2_doctrine_enabled: true
+
 override_parameters: {}
 
 symfony2_composer_opts: '{{ "--no-dev" if symfony2_project_env == "prod" else "" }} --prefer-dist --optimize-autoloader -n'

--- a/tasks/commands.yml
+++ b/tasks/commands.yml
@@ -19,11 +19,14 @@
 - name: Clear Doctrine metadata cache
   shell: cd {{ symfony2_release_destination }} && if grep -q doctrine/doctrine-bundle composer.lock; then {{symfony2_php_path}} {{symfony2_console_path}} doctrine:cache:clear-metadata -e {{symfony2_project_env}} {{symfony2_console_opts}}; fi
   tags: ['app_cache']
+  when: 'symfony2_doctrine_enabled|bool'
 
 - name: Clear Doctrine result cache
   shell: cd {{ symfony2_release_destination }} && if grep -q doctrine/doctrine-bundle composer.lock; then {{symfony2_php_path}} {{symfony2_console_path}} doctrine:cache:clear-result -e {{symfony2_project_env}} {{symfony2_console_opts}}; fi
   tags: ['app_cache']
+  when: 'symfony2_doctrine_enabled|bool'
 
 - name: Clear Doctrine query cache
   shell: cd {{ symfony2_release_destination }} && if grep -q doctrine/doctrine-bundle composer.lock; then {{symfony2_php_path}} {{symfony2_console_path}} doctrine:cache:clear-query -e {{symfony2_project_env}} {{symfony2_console_opts}}; fi
   tags: ['app_cache']
+  when: 'symfony2_doctrine_enabled|bool'


### PR DESCRIPTION
Setting up a project without doctrine causes things to fail as it can't clear the doctrine caches when certain commands are running.

This adds in a new default var that's set to `true` so existing things will continue working as they did, but it can be set to `false` to disable the doctrine commands from running when no DB is used, or doctrine is not enabled.